### PR TITLE
Open Publications link in a new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,8 @@ Buffalo</a></span></p>
 <p align="center" style="text-align:center"><span style="font-family:Arial,sans-serif"><a style="text-decoration:none" href="https://medicine.buffalo.edu/departments/biomedical-informatics/divisions/biomedical-ontology.html" target="_blank">Department of Biomedical Informatics</a></span></p>
 </td>
 <td style="padding:1pt 4.3pt;border:1pt inset rgb(217,217,217);height:32px" colspan="2">
-<p align="center"><span style="font-family:Arial,sans-serif"><a style="text-decoration:none" href="http://ontology.buffalo.edu/smith/BSPUBLST.pdf" target="_blank">Publications</a> / <a style="text-decoration:none" href="https://www.ncbi.nlm.nih.gov/myncbi/barry.smith.1/bibliography/public/?sort=date&amp;direction=descending" target="_blank">PubMed</a> / <a href="http://scholar.google.com/citations?hl=en&amp;user=icGNWj4AAAAJ&amp;view_op=list_works&amp;pagesize=100" style="text-decoration:none" target="_blank">Google Scholar</a></span></p>
+<p align="center"><span style="font-family:Arial,sans-serif"><a style="text-decoration:none" href="http://ontology.buffalo.edu/smith/BSPUBLST.pdf" target="_blank" rel="noopener noreferrer">Publications</a> / <a style="text-decoration:none" href="https://www.ncbi.nlm.nih.gov/myncbi/barry.smith.1/bibliography/public/?sort=date&amp;direction=descending" target="_blank">PubMed</a> / <a href="http://scholar.google.com/citations?hl=en&amp;user=icGNWj4AAAAJ&amp;view_op=list_works&amp;pagesize=100" style="text-decoration:none" target="_blank">Google Scholar</a></span></p>
+
 </td>
 <td style="padding:1pt 4.3pt;border:1pt inset rgb(217,217,217);width:33%;height:32px">
 <p align="center"><span style="font-family:Arial,sans-serif"><a style="text-decoration:none" href="http://www.buffalo.edu/cas/philosophy/faculty/faculty_directory/smith-b.html" target="_blank">Contact</a></span></p>


### PR DESCRIPTION
This change makes the Publications link open Barry’s PDF in a new browser tab so visitors don’t navigate away from the March25 site.